### PR TITLE
Fix: Remove @pure directive from file input component

### DIFF
--- a/stubs/resources/views/flux/input/file.blade.php
+++ b/stubs/resources/views/flux/input/file.blade.php
@@ -1,5 +1,3 @@
-@pure
-
 @php
 extract(Flux::forwardedAttributes($attributes, [
     'name',


### PR DESCRIPTION
The @pure directive causes Blade compilation errors when used with Livewire Blaze due to the component containing dynamic translation helpers ({!! __() !!}) and PHP conditionals.

Error: 'Cannot end a section without first starting one'

This component cannot be safely optimized at compile-time because:
1. It uses translation helpers that need runtime evaluation
2. It contains PHP conditionals (if/else) for multiple file selection
3. The dynamic wire:model attribute binding requires runtime context

Removing @pure allows the component to render correctly while still maintaining full functionality.

# The scenario

<!-- Describe as succinctly as possible what the bug/problem is. Be sure to include the steps to reproduce the bug, screenshots of the issue, and a self-contained Volt class component, which includes all Blade variable definitions, to reproduce the issue. -->

# The problem

<!-- Describe here in detail what you found is wrong with the current code in this package. Add snippets of code here so the maintainers don't need to search the codebase for the issue. -->

# The solution

<!-- Describe here what you did to fix the problem, whether there were other possible solutions, and why you chose this one. Be sure to include snippets of the code changes you have made and screenshots of the problem fixed after your changes. -->



Fixes livewire/flux#